### PR TITLE
Bug Fixes (Text Box and Double Output)

### DIFF
--- a/WebsiteFiles/3.1/css/main.css
+++ b/WebsiteFiles/3.1/css/main.css
@@ -7,6 +7,17 @@
 /* ----- Helper Mixins ----- */
 /* ----- Page Styles ------ */
 /* Base Styles */
+
+/* manual text insert text box resizing
+    added 4/26/2016 - david walker
+*/
+input
+{
+    width: 4em;
+    margin-left: 4px;
+    margin-right: 4px;    
+}
+
 #note_count1,#note_count2,#note_count3,#note_count4{
 	width:50px;
 }

--- a/WebsiteFiles/3.1/js/scaleOptions.js
+++ b/WebsiteFiles/3.1/js/scaleOptions.js
@@ -108,11 +108,16 @@ function addMorphButton($elem)
 
 /*
 	This removes the morph button.
+    
+    EXTRA OUTPUT BUG: this is the EXTRA Output that is getting added on. dunno why yet.
+    -was location of the bug, fixed the extra Output being added by removing the text
+    
+    -NEED to keep the label or else the rest of the output will be lost randomly, must be tied to it somewhere else
 */
 function removeMorphButton($elem)
 {
 	// Add button to reopen morph window
-    $elem.find("select").eq(1).next().replaceWith("<label>Output:</label>");
+    $elem.find("select").eq(1).next().replaceWith("<label> </label>");
 }
 
 /*
@@ -287,6 +292,9 @@ function LoadScaleOptionsInputTextBox(voices, voiceTotal) {
 
 /*
 	This is the Website panel GUI.
+    
+    EXTRA OUTPUT: This is NOT the one getting added on change
+    this is the location of the original.
 */
 function scaleOptions(numberOfVoice) {
     var voiceCount = numberOfVoice;


### PR DESCRIPTION
Bug Updates as of 4/29

main.css
-added styling code to shrink text box sizes to a more fitting size
screenshots:
https://gyazo.com/5c985d4db931a959b079e8fa1c487d56

scaleOptions.js
-fixed double "Output" bug, added comments in code describing that
